### PR TITLE
Fix for input AMEX authentication code not converted to string

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -14,7 +14,7 @@ monzo_client_secret = os.getenv("monzo_client_secret")
 def truelayer_auth_user():
     print('Please visit the following link and copy the token')
     print(f"https://auth.truelayer.com/?response_type=code&client_id={truelayer_client_id}&scope=info%20accounts%20balance%20cards%20transactions%20direct_debits%20offline_access%20standing_orders&redirect_uri=https://console.truelayer.com/redirect-page&providers=uk-ob-barclaycard%20uk-ob-capital-one%20uk-ob-tesco%20uk-ob-amex")
-    code = input("Please enter the code: ")
+    code = str(input("Please enter the code: "))
     Data.delete().where(Data.key == "truelayer_auth_code").execute()
     Data.create(key="truelayer_auth_code", value=code)
 


### PR DESCRIPTION
Fixes #6.

Adds a conversion to string before `code` is passed to `Data.create()`.